### PR TITLE
fix: マスターモードの1問タイマーを30秒に調整

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -139,7 +139,7 @@ class Game {
     startGame() {
         this.score = 0;
         this.questionCount = 0;
-        this.timeLimit = this.currentOperator === 'intro' ? 15 : this.currentOperator === 'hyper' ? 7 : this.currentOperator === 'master' ? 8 : 5;
+        this.timeLimit = this.currentOperator === 'intro' ? 15 : this.currentOperator === 'hyper' ? 7 : this.currentOperator === 'master' ? 30 : 5;
         this.totalTimeLeft = this.currentOperator === 'intro' ? 120 : this.totalTimeLimit;
         this.isPlaying = true;
         this.sounds.start.play().catch(() => {});


### PR DESCRIPTION
## Summary
- マスターモードの1問あたりのタイマーを 8秒 → 30秒 に変更

## Test plan
- [ ] マスターモードで問題を開始し、タイマーバーが30秒かけて減ることを確認
- [ ] 30秒以内に回答しなかった場合に次の問題へ進むことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)